### PR TITLE
Non-hacky way to exclude ex-teams

### DIFF
--- a/schema-migrate/pre2020/people.sql
+++ b/schema-migrate/pre2020/people.sql
@@ -97,7 +97,7 @@ INNER JOIN people.officerships ON officership_name = name;
 --
 -- Migration from public.officerships to people.officership_teams
 INSERT INTO people.officership_teams(name)
--- TODO: the 2020 schema doesn't have an is_current flag for, so we exclude historic teams for now
+-- TODO: the 2020 schema doesn't have an is_current flag for teams, so we exclude historic teams for now
 SELECT DISTINCT team FROM public.officerships WHERE team IS NOT NULL AND is_current;
 --
 -- Migration from public.officerships to people.officership_team_members

--- a/schema-migrate/pre2020/people.sql
+++ b/schema-migrate/pre2020/people.sql
@@ -97,9 +97,7 @@ INNER JOIN people.officerships ON officership_name = name;
 --
 -- Migration from public.officerships to people.officership_teams
 INSERT INTO people.officership_teams(name)
-SELECT DISTINCT team FROM public.officerships WHERE team IS NOT NULL
--- Marks - temporary hack to avoid "non existent lol"
-AND team <> 'commercial';
+SELECT DISTINCT team FROM public.officerships WHERE team IS NOT NULL AND is_current;
 --
 -- Migration from public.officerships to people.officership_team_members
 INSERT INTO people.officership_team_members(team_id, officer_id, is_leader, is_deputy)

--- a/schema-migrate/pre2020/people.sql
+++ b/schema-migrate/pre2020/people.sql
@@ -97,7 +97,7 @@ INNER JOIN people.officerships ON officership_name = name;
 --
 -- Migration from public.officerships to people.officership_teams
 INSERT INTO people.officership_teams(name)
--- TODO: the 2020 schema doesn't have an is_current flag for teams, so we exclude historic teams for now
+-- TODO(https://ystv.atlassian.net/browse/WEB-122): the 2020 schema doesn't have an is_current flag for teams, so we exclude historic teams for now
 SELECT DISTINCT team FROM public.officerships WHERE team IS NOT NULL AND is_current;
 --
 -- Migration from public.officerships to people.officership_team_members

--- a/schema-migrate/pre2020/people.sql
+++ b/schema-migrate/pre2020/people.sql
@@ -97,6 +97,7 @@ INNER JOIN people.officerships ON officership_name = name;
 --
 -- Migration from public.officerships to people.officership_teams
 INSERT INTO people.officership_teams(name)
+-- TODO: the 2020 schema doesn't have an is_current flag for, so we exclude historic teams for now
 SELECT DISTINCT team FROM public.officerships WHERE team IS NOT NULL AND is_current;
 --
 -- Migration from public.officerships to people.officership_team_members


### PR DESCRIPTION
```
ystv=# SELECT DISTINCT team FROM officerships;
    team
------------

 admin
 production
 computing
 technical
 commercial
(6 rows)

ystv=# SELECT DISTINCT team FROM officerships WHERE is_current;
    team
------------
 computing
 admin
 technical
 production
(4 rows)
```